### PR TITLE
Feat: implement full rollback API

### DIFF
--- a/src/main/java/com/levita/levita_monitoring/controller/ReportController.java
+++ b/src/main/java/com/levita/levita_monitoring/controller/ReportController.java
@@ -40,4 +40,14 @@ public class ReportController {
         sheetsReportService.updateFullReport(dto, user);
         return ResponseEntity.ok("Отчет успешно загружен");
     }
+
+    @PostMapping("/rollback")
+    public ResponseEntity<?> rollbackReport(@AuthenticationPrincipal User user) throws IOException {
+        log.info("Запрос на откат отчета от пользователя [{}] в локации [{}]",
+                user.getName(),
+                user.getLocation().getName());
+
+        sheetsReportService.rollbackFullReport(user);
+        return ResponseEntity.ok("Откат данных выполнен успешно");
+    }
 }

--- a/src/main/java/com/levita/levita_monitoring/service/SheetsReportService.java
+++ b/src/main/java/com/levita/levita_monitoring/service/SheetsReportService.java
@@ -116,6 +116,21 @@ public class SheetsReportService {
         log.info("Загрузка данных за дату {} завершена за {} мс", today, duration.toMillis());
     }
 
+    public void rollbackFullReport(User user) throws IOException {
+        String today = LocalDate.now().format(dateFormatter);
+        log.info("{} - Начало полного отката данных", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        Instant start = Instant.now();
+        rollbackShiftReport(user, today);
+        rollbackTrialReport(user, today);
+        rollbackCurrentReport(user, today);
+        rollbackOperations(user, today);
+        Instant end = Instant.now();
+
+        Duration duration = Duration.between(start, end);
+        log.info("Полный откат данных за дату {} завершен за {} мс", today, duration.toMillis());
+    }
+
     private void saveOperationsForDate(List<FullReportDto.OperationDto> operations, User user, String today) throws IOException {
         String location = user.getLocation().getName();
         String admin = user.getName();
@@ -199,7 +214,7 @@ public class SheetsReportService {
         log.info("Загружен раздел \"Пробные\" для пользователя [{} ({})]", admin, location);
     }
 
-    public void updateShiftReport(FullReportDto.ShiftReportDto dto, User user, String today) throws IOException {
+    private void updateShiftReport(FullReportDto.ShiftReportDto dto, User user, String today) throws IOException {
         String location = user.getLocation().getName();
         String admin = user.getName();
 
@@ -224,7 +239,7 @@ public class SheetsReportService {
         log.info("Загружен раздел \"Касса в студии\" для пользователя [{} ({})]", admin, location);
     }
 
-    public void updateCurrentReport(FullReportDto.CurrentReportDto dto, User user, String today) throws IOException {
+    private void updateCurrentReport(FullReportDto.CurrentReportDto dto, User user, String today) throws IOException {
         String admin = user.getName();
         String location = user.getLocation().getName();
         String key = String.format("%s (%s)", admin, location);


### PR DESCRIPTION

Summary

This pull request introduces the full functionality for rolling back report data in Google Sheets via the API.

---

Features Implemented

- `POST /api/report/rollback`: fully rollback all records for the current user by date

---

Refactoring

- Extracted reusable `clearRange`, `deleteRows`, `emptyRow`, `getSheetIdByName`
- Removed hardcoded column counts
- Reduced duplication across rollback methods


